### PR TITLE
Use a single place for BOMs, properties and build for kafka profiling example 

### DIFF
--- a/profiling/kafka/kafka-azure-storage-blob-exchange-pooling/pom.xml
+++ b/profiling/kafka/kafka-azure-storage-blob-exchange-pooling/pom.xml
@@ -34,6 +34,10 @@
     <name>Camel Performance :: Profiling :: Kafka Azure Storage Blob Exchange Pooling</name>
     <description>A Kafka to Azure Storage Blob with Exchange Pooling containeraized application to show profiling practices</description>
 
+    <properties>
+       <tcnative.version>2.0.43.Final</tcnative.version>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>io.quarkus</groupId>
@@ -63,6 +67,11 @@
             <groupId>org.apache.camel.kamelets</groupId>
             <artifactId>camel-kamelets-catalog</artifactId>
             <version>${camel-kamelets-catalog.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.netty</groupId>
+            <artifactId>netty-tcnative-boringssl-static</artifactId>
+            <version>${tcnative.version}</version>
         </dependency>
     </dependencies>
 

--- a/profiling/kafka/kafka-azure-storage-blob-exchange-pooling/pom.xml
+++ b/profiling/kafka/kafka-azure-storage-blob-exchange-pooling/pom.xml
@@ -34,52 +34,6 @@
     <name>Camel Performance :: Profiling :: Kafka Azure Storage Blob Exchange Pooling</name>
     <description>A Kafka to Azure Storage Blob with Exchange Pooling containeraized application to show profiling practices</description>
 
-    <properties>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-
-        <exec-maven-plugin.version>3.0.0</exec-maven-plugin.version>
-        <maven-compiler-plugin.version>3.8.1</maven-compiler-plugin.version>
-        <maven.compiler.parameters>true</maven.compiler.parameters>
-        <maven.compiler.source>11</maven.compiler.source>
-        <maven.compiler.target>11</maven.compiler.target>
-
-        <quarkus.version>2.2.0.Final</quarkus.version>
-        <quarkus.container-image.build>true</quarkus.container-image.build>
-        <quarkus.container-image.group>quay.io/oscerd</quarkus.container-image.group>
-        <quarkus.container-image.name>${project.artifactId}</quarkus.container-image.name>
-
-        <camel-k-runtime.version>1.9.0</camel-k-runtime.version>
-        <camel-quarkus.version>2.2.0</camel-quarkus.version>
-        <camel-kamelets-catalog.version>0.4.0</camel-kamelets-catalog.version>
-    </properties>
-
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>io.quarkus</groupId>
-                <artifactId>quarkus-bom</artifactId>
-                <version>${quarkus.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.camel.k</groupId>
-                <artifactId>camel-k-runtime-bom</artifactId>
-                <version>${camel-k-runtime.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.camel.quarkus</groupId>
-                <artifactId>camel-quarkus-bom</artifactId>
-                <version>${camel-quarkus.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
-
     <dependencies>
         <dependency>
             <groupId>io.quarkus</groupId>
@@ -111,31 +65,6 @@
             <version>${camel-kamelets-catalog.version}</version>
         </dependency>
     </dependencies>
-
-    <build>
-        <plugins>
-            <plugin>
-                <groupId>io.quarkus</groupId>
-                <artifactId>quarkus-maven-plugin</artifactId>
-                <version>${quarkus.version}</version>
-                <extensions>true</extensions>
-                <executions>
-                    <execution>
-                        <goals>
-                            <goal>build</goal>
-                            <goal>generate-code</goal>
-                            <goal>generate-code-tests</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-compiler-plugin</artifactId>
-                <version>${maven-compiler-plugin.version}</version>
-            </plugin>
-        </plugins>
-    </build>
 
     <profiles>
         <profile>

--- a/profiling/kafka/kafka-azure-storage-blob/pom.xml
+++ b/profiling/kafka/kafka-azure-storage-blob/pom.xml
@@ -35,11 +35,8 @@
     <description>A Kafka to Azure Storage Blob containeraized application to show profiling practices</description>
 
     <properties>
-        <postgresql-driver-version>42.2.14</postgresql-driver-version>
-        <commons-dbcp2-version>2.8.0</commons-dbcp2-version>
+       <tcnative.version>2.0.43.Final</tcnative.version>
     </properties>
-
-
 
     <dependencies>
         <dependency>

--- a/profiling/kafka/kafka-azure-storage-blob/pom.xml
+++ b/profiling/kafka/kafka-azure-storage-blob/pom.xml
@@ -44,13 +44,13 @@
         <maven.compiler.source>11</maven.compiler.source>
         <maven.compiler.target>11</maven.compiler.target>
 
-        <quarkus.version>2.2.0.Final</quarkus.version>
+        <quarkus.version>2.4.0.Final</quarkus.version>
         <quarkus.container-image.build>true</quarkus.container-image.build>
         <quarkus.container-image.group>quay.io/oscerd</quarkus.container-image.group>
         <quarkus.container-image.name>${project.artifactId}</quarkus.container-image.name>
 
-        <camel-k-runtime.version>1.9.0</camel-k-runtime.version>
-        <camel-quarkus.version>2.2.0</camel-quarkus.version>
+        <camel-k-runtime.version>1.10.0</camel-k-runtime.version>
+        <camel-quarkus.version>2.4.0</camel-quarkus.version>
         <camel-kamelets-catalog.version>0.4.0</camel-kamelets-catalog.version>
     </properties>
 

--- a/profiling/kafka/kafka-azure-storage-blob/pom.xml
+++ b/profiling/kafka/kafka-azure-storage-blob/pom.xml
@@ -34,51 +34,6 @@
     <name>Camel Performance :: Profiling :: Kafka Azure Storage Blob</name>
     <description>A Kafka to Azure Storage Blob containeraized application to show profiling practices</description>
 
-    <properties>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-
-        <exec-maven-plugin.version>3.0.0</exec-maven-plugin.version>
-        <maven-compiler-plugin.version>3.8.1</maven-compiler-plugin.version>
-        <maven.compiler.parameters>true</maven.compiler.parameters>
-        <maven.compiler.source>11</maven.compiler.source>
-        <maven.compiler.target>11</maven.compiler.target>
-
-        <quarkus.version>2.4.0.Final</quarkus.version>
-        <quarkus.container-image.build>true</quarkus.container-image.build>
-        <quarkus.container-image.group>quay.io/oscerd</quarkus.container-image.group>
-        <quarkus.container-image.name>${project.artifactId}</quarkus.container-image.name>
-
-        <camel-k-runtime.version>1.10.0</camel-k-runtime.version>
-        <camel-quarkus.version>2.4.0</camel-quarkus.version>
-        <camel-kamelets-catalog.version>0.5.0</camel-kamelets-catalog.version>
-    </properties>
-
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>io.quarkus</groupId>
-                <artifactId>quarkus-bom</artifactId>
-                <version>${quarkus.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.camel.k</groupId>
-                <artifactId>camel-k-runtime-bom</artifactId>
-                <version>${camel-k-runtime.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.camel.quarkus</groupId>
-                <artifactId>camel-quarkus-bom</artifactId>
-                <version>${camel-quarkus.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
 
     <dependencies>
         <dependency>

--- a/profiling/kafka/kafka-azure-storage-blob/pom.xml
+++ b/profiling/kafka/kafka-azure-storage-blob/pom.xml
@@ -34,6 +34,12 @@
     <name>Camel Performance :: Profiling :: Kafka Azure Storage Blob</name>
     <description>A Kafka to Azure Storage Blob containeraized application to show profiling practices</description>
 
+    <properties>
+        <postgresql-driver-version>42.2.14</postgresql-driver-version>
+        <commons-dbcp2-version>2.8.0</commons-dbcp2-version>
+    </properties>
+
+
 
     <dependencies>
         <dependency>
@@ -64,6 +70,11 @@
             <groupId>org.apache.camel.kamelets</groupId>
             <artifactId>camel-kamelets-catalog</artifactId>
             <version>${camel-kamelets-catalog.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.netty</groupId>
+            <artifactId>netty-tcnative-boringssl-static</artifactId>
+            <version>${tcnative.version}</version>
         </dependency>
     </dependencies>
 

--- a/profiling/kafka/kafka-azure-storage-blob/pom.xml
+++ b/profiling/kafka/kafka-azure-storage-blob/pom.xml
@@ -51,7 +51,7 @@
 
         <camel-k-runtime.version>1.10.0</camel-k-runtime.version>
         <camel-quarkus.version>2.4.0</camel-quarkus.version>
-        <camel-kamelets-catalog.version>0.4.0</camel-kamelets-catalog.version>
+        <camel-kamelets-catalog.version>0.5.0</camel-kamelets-catalog.version>
     </properties>
 
     <dependencyManagement>

--- a/profiling/kafka/kafka-azure-storage-blob/pom.xml
+++ b/profiling/kafka/kafka-azure-storage-blob/pom.xml
@@ -67,31 +67,6 @@
         </dependency>
     </dependencies>
 
-    <build>
-        <plugins>
-            <plugin>
-                <groupId>io.quarkus</groupId>
-                <artifactId>quarkus-maven-plugin</artifactId>
-                <version>${quarkus.version}</version>
-                <extensions>true</extensions>
-                <executions>
-                    <execution>
-                        <goals>
-                            <goal>build</goal>
-                            <goal>generate-code</goal>
-                            <goal>generate-code-tests</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-compiler-plugin</artifactId>
-                <version>${maven-compiler-plugin.version}</version>
-            </plugin>
-        </plugins>
-    </build>
-
     <profiles>
         <profile>
             <id>jvm</id>

--- a/profiling/kafka/kafka-minio-exchange-pooling/pom.xml
+++ b/profiling/kafka/kafka-minio-exchange-pooling/pom.xml
@@ -34,52 +34,6 @@
     <name>Camel Performance :: Profiling :: Kafka Minio Exchange Pooling</name>
     <description>A Kafka to Minio with Exchange Pooling containeraized application to show profiling practices</description>
 
-    <properties>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-
-        <exec-maven-plugin.version>3.0.0</exec-maven-plugin.version>
-        <maven-compiler-plugin.version>3.8.1</maven-compiler-plugin.version>
-        <maven.compiler.parameters>true</maven.compiler.parameters>
-        <maven.compiler.source>11</maven.compiler.source>
-        <maven.compiler.target>11</maven.compiler.target>
-
-        <quarkus.version>2.2.0.Final</quarkus.version>
-        <quarkus.container-image.build>true</quarkus.container-image.build>
-        <quarkus.container-image.group>quay.io/oscerd</quarkus.container-image.group>
-        <quarkus.container-image.name>${project.artifactId}</quarkus.container-image.name>
-
-        <camel-k-runtime.version>1.9.0</camel-k-runtime.version>
-        <camel-quarkus.version>2.2.0</camel-quarkus.version>
-        <camel-kamelets-catalog.version>0.4.0</camel-kamelets-catalog.version>
-    </properties>
-
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>io.quarkus</groupId>
-                <artifactId>quarkus-bom</artifactId>
-                <version>${quarkus.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.camel.k</groupId>
-                <artifactId>camel-k-runtime-bom</artifactId>
-                <version>${camel-k-runtime.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.camel.quarkus</groupId>
-                <artifactId>camel-quarkus-bom</artifactId>
-                <version>${camel-quarkus.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
-
     <dependencies>
         <dependency>
             <groupId>io.quarkus</groupId>
@@ -111,31 +65,6 @@
             <version>${camel-kamelets-catalog.version}</version>
         </dependency>
     </dependencies>
-
-    <build>
-        <plugins>
-            <plugin>
-                <groupId>io.quarkus</groupId>
-                <artifactId>quarkus-maven-plugin</artifactId>
-                <version>${quarkus.version}</version>
-                <extensions>true</extensions>
-                <executions>
-                    <execution>
-                        <goals>
-                            <goal>build</goal>
-                            <goal>generate-code</goal>
-                            <goal>generate-code-tests</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-compiler-plugin</artifactId>
-                <version>${maven-compiler-plugin.version}</version>
-            </plugin>
-        </plugins>
-    </build>
 
     <profiles>
         <profile>

--- a/profiling/kafka/kafka-minio/pom.xml
+++ b/profiling/kafka/kafka-minio/pom.xml
@@ -34,52 +34,6 @@
     <name>Camel Performance :: Profiling :: Kafka Minio</name>
     <description>A Kafka to Minio containeraized application to show profiling practices</description>
 
-    <properties>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-
-        <exec-maven-plugin.version>3.0.0</exec-maven-plugin.version>
-        <maven-compiler-plugin.version>3.8.1</maven-compiler-plugin.version>
-        <maven.compiler.parameters>true</maven.compiler.parameters>
-        <maven.compiler.source>11</maven.compiler.source>
-        <maven.compiler.target>11</maven.compiler.target>
-
-        <quarkus.version>2.2.0.Final</quarkus.version>
-        <quarkus.container-image.build>true</quarkus.container-image.build>
-        <quarkus.container-image.group>quay.io/oscerd</quarkus.container-image.group>
-        <quarkus.container-image.name>${project.artifactId}</quarkus.container-image.name>
-
-        <camel-k-runtime.version>1.9.0</camel-k-runtime.version>
-        <camel-quarkus.version>2.2.0</camel-quarkus.version>
-        <camel-kamelets-catalog.version>0.4.0</camel-kamelets-catalog.version>
-    </properties>
-
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>io.quarkus</groupId>
-                <artifactId>quarkus-bom</artifactId>
-                <version>${quarkus.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.camel.k</groupId>
-                <artifactId>camel-k-runtime-bom</artifactId>
-                <version>${camel-k-runtime.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.camel.quarkus</groupId>
-                <artifactId>camel-quarkus-bom</artifactId>
-                <version>${camel-quarkus.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
-
     <dependencies>
         <dependency>
             <groupId>io.quarkus</groupId>
@@ -111,31 +65,6 @@
             <version>${camel-kamelets-catalog.version}</version>
         </dependency>
     </dependencies>
-
-    <build>
-        <plugins>
-            <plugin>
-                <groupId>io.quarkus</groupId>
-                <artifactId>quarkus-maven-plugin</artifactId>
-                <version>${quarkus.version}</version>
-                <extensions>true</extensions>
-                <executions>
-                    <execution>
-                        <goals>
-                            <goal>build</goal>
-                            <goal>generate-code</goal>
-                            <goal>generate-code-tests</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-compiler-plugin</artifactId>
-                <version>${maven-compiler-plugin.version}</version>
-            </plugin>
-        </plugins>
-    </build>
 
     <profiles>
         <profile>

--- a/profiling/kafka/kafka-mongo-exchange-pooling/pom.xml
+++ b/profiling/kafka/kafka-mongo-exchange-pooling/pom.xml
@@ -34,52 +34,6 @@
     <name>Camel Performance :: Profiling :: Kafka MongoDB Exchange Pooling</name>
     <description>A Kafka to MongoDB with Exchange pooling containeraized application to show profiling practices</description>
 
-    <properties>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-
-        <exec-maven-plugin.version>3.0.0</exec-maven-plugin.version>
-        <maven-compiler-plugin.version>3.8.1</maven-compiler-plugin.version>
-        <maven.compiler.parameters>true</maven.compiler.parameters>
-        <maven.compiler.source>11</maven.compiler.source>
-        <maven.compiler.target>11</maven.compiler.target>
-
-        <quarkus.version>2.2.0.Final</quarkus.version>
-        <quarkus.container-image.build>true</quarkus.container-image.build>
-        <quarkus.container-image.group>quay.io/oscerd</quarkus.container-image.group>
-        <quarkus.container-image.name>${project.artifactId}</quarkus.container-image.name>
-
-        <camel-k-runtime.version>1.9.0</camel-k-runtime.version>
-        <camel-quarkus.version>2.2.0</camel-quarkus.version>
-        <camel-kamelets-catalog.version>0.4.0</camel-kamelets-catalog.version>
-    </properties>
-
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>io.quarkus</groupId>
-                <artifactId>quarkus-bom</artifactId>
-                <version>${quarkus.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.camel.k</groupId>
-                <artifactId>camel-k-runtime-bom</artifactId>
-                <version>${camel-k-runtime.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.camel.quarkus</groupId>
-                <artifactId>camel-quarkus-bom</artifactId>
-                <version>${camel-quarkus.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
-
     <dependencies>
         <dependency>
             <groupId>io.quarkus</groupId>
@@ -111,31 +65,6 @@
             <version>${camel-kamelets-catalog.version}</version>
         </dependency>
     </dependencies>
-
-    <build>
-        <plugins>
-            <plugin>
-                <groupId>io.quarkus</groupId>
-                <artifactId>quarkus-maven-plugin</artifactId>
-                <version>${quarkus.version}</version>
-                <extensions>true</extensions>
-                <executions>
-                    <execution>
-                        <goals>
-                            <goal>build</goal>
-                            <goal>generate-code</goal>
-                            <goal>generate-code-tests</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-compiler-plugin</artifactId>
-                <version>${maven-compiler-plugin.version}</version>
-            </plugin>
-        </plugins>
-    </build>
 
     <profiles>
         <profile>

--- a/profiling/kafka/kafka-mongo/pom.xml
+++ b/profiling/kafka/kafka-mongo/pom.xml
@@ -34,52 +34,6 @@
     <name>Camel Performance :: Profiling :: Kafka MongoDB</name>
     <description>A Kafka to MongoDB containeraized application to show profiling practices</description>
 
-    <properties>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-
-        <exec-maven-plugin.version>3.0.0</exec-maven-plugin.version>
-        <maven-compiler-plugin.version>3.8.1</maven-compiler-plugin.version>
-        <maven.compiler.parameters>true</maven.compiler.parameters>
-        <maven.compiler.source>11</maven.compiler.source>
-        <maven.compiler.target>11</maven.compiler.target>
-
-        <quarkus.version>2.2.0.Final</quarkus.version>
-        <quarkus.container-image.build>true</quarkus.container-image.build>
-        <quarkus.container-image.group>quay.io/oscerd</quarkus.container-image.group>
-        <quarkus.container-image.name>${project.artifactId}</quarkus.container-image.name>
-
-        <camel-k-runtime.version>1.9.0</camel-k-runtime.version>
-        <camel-quarkus.version>2.2.0</camel-quarkus.version>
-        <camel-kamelets-catalog.version>0.4.0</camel-kamelets-catalog.version>
-    </properties>
-
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>io.quarkus</groupId>
-                <artifactId>quarkus-bom</artifactId>
-                <version>${quarkus.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.camel.k</groupId>
-                <artifactId>camel-k-runtime-bom</artifactId>
-                <version>${camel-k-runtime.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.camel.quarkus</groupId>
-                <artifactId>camel-quarkus-bom</artifactId>
-                <version>${camel-quarkus.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
-
     <dependencies>
         <dependency>
             <groupId>io.quarkus</groupId>
@@ -111,31 +65,6 @@
             <version>${camel-kamelets-catalog.version}</version>
         </dependency>
     </dependencies>
-
-    <build>
-        <plugins>
-            <plugin>
-                <groupId>io.quarkus</groupId>
-                <artifactId>quarkus-maven-plugin</artifactId>
-                <version>${quarkus.version}</version>
-                <extensions>true</extensions>
-                <executions>
-                    <execution>
-                        <goals>
-                            <goal>build</goal>
-                            <goal>generate-code</goal>
-                            <goal>generate-code-tests</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-compiler-plugin</artifactId>
-                <version>${maven-compiler-plugin.version}</version>
-            </plugin>
-        </plugins>
-    </build>
 
     <profiles>
         <profile>

--- a/profiling/kafka/kafka-nats-exchange-pooling/pom.xml
+++ b/profiling/kafka/kafka-nats-exchange-pooling/pom.xml
@@ -34,52 +34,6 @@
     <name>Camel Performance :: Profiling :: Kafka Nats Exchange Pooling</name>
     <description>A Kafka to Nats with Exchange Pooling containeraized application to show profiling practices</description>
 
-    <properties>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-
-        <exec-maven-plugin.version>3.0.0</exec-maven-plugin.version>
-        <maven-compiler-plugin.version>3.8.1</maven-compiler-plugin.version>
-        <maven.compiler.parameters>true</maven.compiler.parameters>
-        <maven.compiler.source>11</maven.compiler.source>
-        <maven.compiler.target>11</maven.compiler.target>
-
-        <quarkus.version>2.2.0.Final</quarkus.version>
-        <quarkus.container-image.build>true</quarkus.container-image.build>
-        <quarkus.container-image.group>quay.io/oscerd</quarkus.container-image.group>
-        <quarkus.container-image.name>${project.artifactId}</quarkus.container-image.name>
-
-        <camel-k-runtime.version>1.9.0</camel-k-runtime.version>
-        <camel-quarkus.version>2.2.0</camel-quarkus.version>
-        <camel-kamelets-catalog.version>0.4.0</camel-kamelets-catalog.version>
-    </properties>
-
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>io.quarkus</groupId>
-                <artifactId>quarkus-bom</artifactId>
-                <version>${quarkus.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.camel.k</groupId>
-                <artifactId>camel-k-runtime-bom</artifactId>
-                <version>${camel-k-runtime.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.camel.quarkus</groupId>
-                <artifactId>camel-quarkus-bom</artifactId>
-                <version>${camel-quarkus.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
-
     <dependencies>
         <dependency>
             <groupId>io.quarkus</groupId>
@@ -111,31 +65,6 @@
             <version>${camel-kamelets-catalog.version}</version>
         </dependency>
     </dependencies>
-
-    <build>
-        <plugins>
-            <plugin>
-                <groupId>io.quarkus</groupId>
-                <artifactId>quarkus-maven-plugin</artifactId>
-                <version>${quarkus.version}</version>
-                <extensions>true</extensions>
-                <executions>
-                    <execution>
-                        <goals>
-                            <goal>build</goal>
-                            <goal>generate-code</goal>
-                            <goal>generate-code-tests</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-compiler-plugin</artifactId>
-                <version>${maven-compiler-plugin.version}</version>
-            </plugin>
-        </plugins>
-    </build>
 
     <profiles>
         <profile>

--- a/profiling/kafka/kafka-nats/pom.xml
+++ b/profiling/kafka/kafka-nats/pom.xml
@@ -34,52 +34,6 @@
     <name>Camel Performance :: Profiling :: Kafka Nats</name>
     <description>A Kafka to Nats containeraized application to show profiling practices</description>
 
-    <properties>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-
-        <exec-maven-plugin.version>3.0.0</exec-maven-plugin.version>
-        <maven-compiler-plugin.version>3.8.1</maven-compiler-plugin.version>
-        <maven.compiler.parameters>true</maven.compiler.parameters>
-        <maven.compiler.source>11</maven.compiler.source>
-        <maven.compiler.target>11</maven.compiler.target>
-
-        <quarkus.version>2.2.0.Final</quarkus.version>
-        <quarkus.container-image.build>true</quarkus.container-image.build>
-        <quarkus.container-image.group>quay.io/oscerd</quarkus.container-image.group>
-        <quarkus.container-image.name>${project.artifactId}</quarkus.container-image.name>
-
-        <camel-k-runtime.version>1.9.0</camel-k-runtime.version>
-        <camel-quarkus.version>2.2.0</camel-quarkus.version>
-        <camel-kamelets-catalog.version>0.4.0</camel-kamelets-catalog.version>
-    </properties>
-
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>io.quarkus</groupId>
-                <artifactId>quarkus-bom</artifactId>
-                <version>${quarkus.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.camel.k</groupId>
-                <artifactId>camel-k-runtime-bom</artifactId>
-                <version>${camel-k-runtime.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.camel.quarkus</groupId>
-                <artifactId>camel-quarkus-bom</artifactId>
-                <version>${camel-quarkus.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
-
     <dependencies>
         <dependency>
             <groupId>io.quarkus</groupId>
@@ -111,31 +65,6 @@
             <version>${camel-kamelets-catalog.version}</version>
         </dependency>
     </dependencies>
-
-    <build>
-        <plugins>
-            <plugin>
-                <groupId>io.quarkus</groupId>
-                <artifactId>quarkus-maven-plugin</artifactId>
-                <version>${quarkus.version}</version>
-                <extensions>true</extensions>
-                <executions>
-                    <execution>
-                        <goals>
-                            <goal>build</goal>
-                            <goal>generate-code</goal>
-                            <goal>generate-code-tests</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-compiler-plugin</artifactId>
-                <version>${maven-compiler-plugin.version}</version>
-            </plugin>
-        </plugins>
-    </build>
 
     <profiles>
         <profile>

--- a/profiling/kafka/kafka-postgresql-exchange-pooling/pom.xml
+++ b/profiling/kafka/kafka-postgresql-exchange-pooling/pom.xml
@@ -34,6 +34,37 @@
     <name>Camel Performance :: Profiling :: Kafka PostgreSQL Exchange Pooling</name>
     <description>A Kafka to PostgreSQL with exchange pooling containeraized application to show profiling practices</description>
 
+    <properties>
+        <postgresql-driver-version>42.2.14</postgresql-driver-version>
+        <commons-dbcp2-version>2.8.0</commons-dbcp2-version>
+    </properties>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>io.quarkus</groupId>
+                <artifactId>quarkus-bom</artifactId>
+                <version>${quarkus.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.camel.k</groupId>
+                <artifactId>camel-k-runtime-bom</artifactId>
+                <version>${camel-k-runtime.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.camel.quarkus</groupId>
+                <artifactId>camel-quarkus-bom</artifactId>
+                <version>${camel-quarkus.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
     <dependencies>
         <dependency>
             <groupId>io.quarkus</groupId>

--- a/profiling/kafka/kafka-postgresql-exchange-pooling/pom.xml
+++ b/profiling/kafka/kafka-postgresql-exchange-pooling/pom.xml
@@ -34,54 +34,6 @@
     <name>Camel Performance :: Profiling :: Kafka PostgreSQL Exchange Pooling</name>
     <description>A Kafka to PostgreSQL with exchange pooling containeraized application to show profiling practices</description>
 
-    <properties>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-
-        <exec-maven-plugin.version>3.0.0</exec-maven-plugin.version>
-        <maven-compiler-plugin.version>3.8.1</maven-compiler-plugin.version>
-        <maven.compiler.parameters>true</maven.compiler.parameters>
-        <maven.compiler.source>11</maven.compiler.source>
-        <maven.compiler.target>11</maven.compiler.target>
-
-        <quarkus.version>2.2.0.Final</quarkus.version>
-        <quarkus.container-image.build>true</quarkus.container-image.build>
-        <quarkus.container-image.group>quay.io/oscerd</quarkus.container-image.group>
-        <quarkus.container-image.name>${project.artifactId}</quarkus.container-image.name>
-
-        <camel-k-runtime.version>1.9.0</camel-k-runtime.version>
-        <camel-quarkus.version>2.2.0</camel-quarkus.version>
-        <camel-kamelets-catalog.version>0.4.0</camel-kamelets-catalog.version>
-        <postgresql-driver-version>42.2.14</postgresql-driver-version>
-        <commons-dbcp2-version>2.8.0</commons-dbcp2-version>
-    </properties>
-
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>io.quarkus</groupId>
-                <artifactId>quarkus-bom</artifactId>
-                <version>${quarkus.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.camel.k</groupId>
-                <artifactId>camel-k-runtime-bom</artifactId>
-                <version>${camel-k-runtime.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.camel.quarkus</groupId>
-                <artifactId>camel-quarkus-bom</artifactId>
-                <version>${camel-quarkus.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
-
     <dependencies>
         <dependency>
             <groupId>io.quarkus</groupId>
@@ -127,31 +79,6 @@
             <version>${postgresql-driver-version}</version>
         </dependency>
     </dependencies>
-
-    <build>
-        <plugins>
-            <plugin>
-                <groupId>io.quarkus</groupId>
-                <artifactId>quarkus-maven-plugin</artifactId>
-                <version>${quarkus.version}</version>
-                <extensions>true</extensions>
-                <executions>
-                    <execution>
-                        <goals>
-                            <goal>build</goal>
-                            <goal>generate-code</goal>
-                            <goal>generate-code-tests</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-compiler-plugin</artifactId>
-                <version>${maven-compiler-plugin.version}</version>
-            </plugin>
-        </plugins>
-    </build>
 
     <profiles>
         <profile>

--- a/profiling/kafka/kafka-postgresql/pom.xml
+++ b/profiling/kafka/kafka-postgresql/pom.xml
@@ -34,54 +34,6 @@
     <name>Camel Performance :: Profiling :: Kafka PostgreSQL</name>
     <description>A Kafka to PostgreSQL containeraized application to show profiling practices</description>
 
-    <properties>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-
-        <exec-maven-plugin.version>3.0.0</exec-maven-plugin.version>
-        <maven-compiler-plugin.version>3.8.1</maven-compiler-plugin.version>
-        <maven.compiler.parameters>true</maven.compiler.parameters>
-        <maven.compiler.source>11</maven.compiler.source>
-        <maven.compiler.target>11</maven.compiler.target>
-
-        <quarkus.version>2.2.0.Final</quarkus.version>
-        <quarkus.container-image.build>true</quarkus.container-image.build>
-        <quarkus.container-image.group>quay.io/oscerd</quarkus.container-image.group>
-        <quarkus.container-image.name>${project.artifactId}</quarkus.container-image.name>
-
-        <camel-k-runtime.version>1.9.0</camel-k-runtime.version>
-        <camel-quarkus.version>2.2.0</camel-quarkus.version>
-        <camel-kamelets-catalog.version>0.4.0</camel-kamelets-catalog.version>
-        <postgresql-driver-version>42.2.14</postgresql-driver-version>
-        <commons-dbcp2-version>2.8.0</commons-dbcp2-version>
-    </properties>
-
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>io.quarkus</groupId>
-                <artifactId>quarkus-bom</artifactId>
-                <version>${quarkus.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.camel.k</groupId>
-                <artifactId>camel-k-runtime-bom</artifactId>
-                <version>${camel-k-runtime.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.camel.quarkus</groupId>
-                <artifactId>camel-quarkus-bom</artifactId>
-                <version>${camel-quarkus.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
-
     <dependencies>
         <dependency>
             <groupId>io.quarkus</groupId>
@@ -127,31 +79,6 @@
             <version>${postgresql-driver-version}</version>
         </dependency>
     </dependencies>
-
-    <build>
-        <plugins>
-            <plugin>
-                <groupId>io.quarkus</groupId>
-                <artifactId>quarkus-maven-plugin</artifactId>
-                <version>${quarkus.version}</version>
-                <extensions>true</extensions>
-                <executions>
-                    <execution>
-                        <goals>
-                            <goal>build</goal>
-                            <goal>generate-code</goal>
-                            <goal>generate-code-tests</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-compiler-plugin</artifactId>
-                <version>${maven-compiler-plugin.version}</version>
-            </plugin>
-        </plugins>
-    </build>
 
     <profiles>
         <profile>

--- a/profiling/kafka/kafka-postgresql/pom.xml
+++ b/profiling/kafka/kafka-postgresql/pom.xml
@@ -34,6 +34,37 @@
     <name>Camel Performance :: Profiling :: Kafka PostgreSQL</name>
     <description>A Kafka to PostgreSQL containeraized application to show profiling practices</description>
 
+    <properties>
+        <postgresql-driver-version>42.2.14</postgresql-driver-version>
+        <commons-dbcp2-version>2.8.0</commons-dbcp2-version>
+    </properties>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>io.quarkus</groupId>
+                <artifactId>quarkus-bom</artifactId>
+                <version>${quarkus.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.camel.k</groupId>
+                <artifactId>camel-k-runtime-bom</artifactId>
+                <version>${camel-k-runtime.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.camel.quarkus</groupId>
+                <artifactId>camel-quarkus-bom</artifactId>
+                <version>${camel-quarkus.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
     <dependencies>
         <dependency>
             <groupId>io.quarkus</groupId>

--- a/profiling/kafka/kafka-s3-exchange-pooling/pom.xml
+++ b/profiling/kafka/kafka-s3-exchange-pooling/pom.xml
@@ -34,52 +34,6 @@
     <name>Camel Performance :: Profiling :: Kafka S3 Exchange Pooling</name>
     <description>A Kafka to S3 with Exchange Pooling containeraized application to show profiling practices</description>
 
-    <properties>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-
-        <exec-maven-plugin.version>3.0.0</exec-maven-plugin.version>
-        <maven-compiler-plugin.version>3.8.1</maven-compiler-plugin.version>
-        <maven.compiler.parameters>true</maven.compiler.parameters>
-        <maven.compiler.source>11</maven.compiler.source>
-        <maven.compiler.target>11</maven.compiler.target>
-
-        <quarkus.version>2.2.0.Final</quarkus.version>
-        <quarkus.container-image.build>true</quarkus.container-image.build>
-        <quarkus.container-image.group>quay.io/oscerd</quarkus.container-image.group>
-        <quarkus.container-image.name>${project.artifactId}</quarkus.container-image.name>
-
-        <camel-k-runtime.version>1.9.0</camel-k-runtime.version>
-        <camel-quarkus.version>2.2.0</camel-quarkus.version>
-        <camel-kamelets-catalog.version>0.4.0</camel-kamelets-catalog.version>
-    </properties>
-
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>io.quarkus</groupId>
-                <artifactId>quarkus-bom</artifactId>
-                <version>${quarkus.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.camel.k</groupId>
-                <artifactId>camel-k-runtime-bom</artifactId>
-                <version>${camel-k-runtime.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.camel.quarkus</groupId>
-                <artifactId>camel-quarkus-bom</artifactId>
-                <version>${camel-quarkus.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
-
     <dependencies>
         <dependency>
             <groupId>io.quarkus</groupId>
@@ -111,31 +65,6 @@
             <version>${camel-kamelets-catalog.version}</version>
         </dependency>
     </dependencies>
-
-    <build>
-        <plugins>
-            <plugin>
-                <groupId>io.quarkus</groupId>
-                <artifactId>quarkus-maven-plugin</artifactId>
-                <version>${quarkus.version}</version>
-                <extensions>true</extensions>
-                <executions>
-                    <execution>
-                        <goals>
-                            <goal>build</goal>
-                            <goal>generate-code</goal>
-                            <goal>generate-code-tests</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-compiler-plugin</artifactId>
-                <version>${maven-compiler-plugin.version}</version>
-            </plugin>
-        </plugins>
-    </build>
 
     <profiles>
         <profile>

--- a/profiling/kafka/kafka-s3/pom.xml
+++ b/profiling/kafka/kafka-s3/pom.xml
@@ -34,52 +34,6 @@
     <name>Camel Performance :: Profiling :: Kafka S3</name>
     <description>A Kafka to S3 containeraized application to show profiling practices</description>
 
-    <properties>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-
-        <exec-maven-plugin.version>3.0.0</exec-maven-plugin.version>
-        <maven-compiler-plugin.version>3.8.1</maven-compiler-plugin.version>
-        <maven.compiler.parameters>true</maven.compiler.parameters>
-        <maven.compiler.source>11</maven.compiler.source>
-        <maven.compiler.target>11</maven.compiler.target>
-
-        <quarkus.version>2.2.0.Final</quarkus.version>
-        <quarkus.container-image.build>true</quarkus.container-image.build>
-        <quarkus.container-image.group>quay.io/oscerd</quarkus.container-image.group>
-        <quarkus.container-image.name>${project.artifactId}</quarkus.container-image.name>
-
-        <camel-k-runtime.version>1.9.0</camel-k-runtime.version>
-        <camel-quarkus.version>2.2.0</camel-quarkus.version>
-        <camel-kamelets-catalog.version>0.4.0</camel-kamelets-catalog.version>
-    </properties>
-
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>io.quarkus</groupId>
-                <artifactId>quarkus-bom</artifactId>
-                <version>${quarkus.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.camel.k</groupId>
-                <artifactId>camel-k-runtime-bom</artifactId>
-                <version>${camel-k-runtime.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.camel.quarkus</groupId>
-                <artifactId>camel-quarkus-bom</artifactId>
-                <version>${camel-quarkus.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
-
     <dependencies>
         <dependency>
             <groupId>io.quarkus</groupId>
@@ -111,31 +65,6 @@
             <version>${camel-kamelets-catalog.version}</version>
         </dependency>
     </dependencies>
-
-    <build>
-        <plugins>
-            <plugin>
-                <groupId>io.quarkus</groupId>
-                <artifactId>quarkus-maven-plugin</artifactId>
-                <version>${quarkus.version}</version>
-                <extensions>true</extensions>
-                <executions>
-                    <execution>
-                        <goals>
-                            <goal>build</goal>
-                            <goal>generate-code</goal>
-                            <goal>generate-code-tests</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-compiler-plugin</artifactId>
-                <version>${maven-compiler-plugin.version}</version>
-            </plugin>
-        </plugins>
-    </build>
 
     <profiles>
         <profile>

--- a/profiling/kafka/kafka-sqs-exchange-pooling/pom.xml
+++ b/profiling/kafka/kafka-sqs-exchange-pooling/pom.xml
@@ -34,52 +34,6 @@
     <name>Camel Performance :: Profiling :: Kafka SQS Exchange Pooling</name>
     <description>A Kafka to SQS with Exchange Pooling containeraized application to show profiling practices</description>
 
-    <properties>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-
-        <exec-maven-plugin.version>3.0.0</exec-maven-plugin.version>
-        <maven-compiler-plugin.version>3.8.1</maven-compiler-plugin.version>
-        <maven.compiler.parameters>true</maven.compiler.parameters>
-        <maven.compiler.source>11</maven.compiler.source>
-        <maven.compiler.target>11</maven.compiler.target>
-
-        <quarkus.version>2.2.0.Final</quarkus.version>
-        <quarkus.container-image.build>true</quarkus.container-image.build>
-        <quarkus.container-image.group>quay.io/oscerd</quarkus.container-image.group>
-        <quarkus.container-image.name>${project.artifactId}</quarkus.container-image.name>
-
-        <camel-k-runtime.version>1.9.0</camel-k-runtime.version>
-        <camel-quarkus.version>2.2.0</camel-quarkus.version>
-        <camel-kamelets-catalog.version>0.4.0</camel-kamelets-catalog.version>
-    </properties>
-
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>io.quarkus</groupId>
-                <artifactId>quarkus-bom</artifactId>
-                <version>${quarkus.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.camel.k</groupId>
-                <artifactId>camel-k-runtime-bom</artifactId>
-                <version>${camel-k-runtime.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.camel.quarkus</groupId>
-                <artifactId>camel-quarkus-bom</artifactId>
-                <version>${camel-quarkus.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
-
     <dependencies>
         <dependency>
             <groupId>io.quarkus</groupId>
@@ -111,31 +65,6 @@
             <version>${camel-kamelets-catalog.version}</version>
         </dependency>
     </dependencies>
-
-    <build>
-        <plugins>
-            <plugin>
-                <groupId>io.quarkus</groupId>
-                <artifactId>quarkus-maven-plugin</artifactId>
-                <version>${quarkus.version}</version>
-                <extensions>true</extensions>
-                <executions>
-                    <execution>
-                        <goals>
-                            <goal>build</goal>
-                            <goal>generate-code</goal>
-                            <goal>generate-code-tests</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-compiler-plugin</artifactId>
-                <version>${maven-compiler-plugin.version}</version>
-            </plugin>
-        </plugins>
-    </build>
 
     <profiles>
         <profile>

--- a/profiling/kafka/kafka-sqs/pom.xml
+++ b/profiling/kafka/kafka-sqs/pom.xml
@@ -34,52 +34,6 @@
     <name>Camel Performance :: Profiling :: Kafka SQS</name>
     <description>A Kafka to SQS containeraized application to show profiling practices</description>
 
-    <properties>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-
-        <exec-maven-plugin.version>3.0.0</exec-maven-plugin.version>
-        <maven-compiler-plugin.version>3.8.1</maven-compiler-plugin.version>
-        <maven.compiler.parameters>true</maven.compiler.parameters>
-        <maven.compiler.source>11</maven.compiler.source>
-        <maven.compiler.target>11</maven.compiler.target>
-
-        <quarkus.version>2.2.0.Final</quarkus.version>
-        <quarkus.container-image.build>true</quarkus.container-image.build>
-        <quarkus.container-image.group>quay.io/oscerd</quarkus.container-image.group>
-        <quarkus.container-image.name>${project.artifactId}</quarkus.container-image.name>
-
-        <camel-k-runtime.version>1.9.0</camel-k-runtime.version>
-        <camel-quarkus.version>2.2.0</camel-quarkus.version>
-        <camel-kamelets-catalog.version>0.4.0</camel-kamelets-catalog.version>
-    </properties>
-
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>io.quarkus</groupId>
-                <artifactId>quarkus-bom</artifactId>
-                <version>${quarkus.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.camel.k</groupId>
-                <artifactId>camel-k-runtime-bom</artifactId>
-                <version>${camel-k-runtime.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.camel.quarkus</groupId>
-                <artifactId>camel-quarkus-bom</artifactId>
-                <version>${camel-quarkus.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
-
     <dependencies>
         <dependency>
             <groupId>io.quarkus</groupId>
@@ -111,31 +65,6 @@
             <version>${camel-kamelets-catalog.version}</version>
         </dependency>
     </dependencies>
-
-    <build>
-        <plugins>
-            <plugin>
-                <groupId>io.quarkus</groupId>
-                <artifactId>quarkus-maven-plugin</artifactId>
-                <version>${quarkus.version}</version>
-                <extensions>true</extensions>
-                <executions>
-                    <execution>
-                        <goals>
-                            <goal>build</goal>
-                            <goal>generate-code</goal>
-                            <goal>generate-code-tests</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-compiler-plugin</artifactId>
-                <version>${maven-compiler-plugin.version}</version>
-            </plugin>
-        </plugins>
-    </build>
 
     <profiles>
         <profile>

--- a/profiling/kafka/minio-kafka-exchange-pooling/pom.xml
+++ b/profiling/kafka/minio-kafka-exchange-pooling/pom.xml
@@ -34,52 +34,6 @@
     <name>Camel Performance :: Profiling :: Minio Kafka Exchange Pooling</name>
     <description>A Minio to Kafka with exchange pooling containeraized application to show profiling practices</description>
 
-    <properties>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-
-        <exec-maven-plugin.version>3.0.0</exec-maven-plugin.version>
-        <maven-compiler-plugin.version>3.8.1</maven-compiler-plugin.version>
-        <maven.compiler.parameters>true</maven.compiler.parameters>
-        <maven.compiler.source>11</maven.compiler.source>
-        <maven.compiler.target>11</maven.compiler.target>
-
-        <quarkus.version>2.2.0.Final</quarkus.version>
-        <quarkus.container-image.build>true</quarkus.container-image.build>
-        <quarkus.container-image.group>quay.io/oscerd</quarkus.container-image.group>
-        <quarkus.container-image.name>${project.artifactId}</quarkus.container-image.name>
-
-        <camel-k-runtime.version>1.9.0</camel-k-runtime.version>
-        <camel-quarkus.version>2.2.0</camel-quarkus.version>
-        <camel-kamelets-catalog.version>0.4.0</camel-kamelets-catalog.version>
-    </properties>
-
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>io.quarkus</groupId>
-                <artifactId>quarkus-bom</artifactId>
-                <version>${quarkus.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.camel.k</groupId>
-                <artifactId>camel-k-runtime-bom</artifactId>
-                <version>${camel-k-runtime.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.camel.quarkus</groupId>
-                <artifactId>camel-quarkus-bom</artifactId>
-                <version>${camel-quarkus.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
-
     <dependencies>
         <dependency>
             <groupId>io.quarkus</groupId>
@@ -115,31 +69,6 @@
             <version>${camel-kamelets-catalog.version}</version>
         </dependency>
     </dependencies>
-
-    <build>
-        <plugins>
-            <plugin>
-                <groupId>io.quarkus</groupId>
-                <artifactId>quarkus-maven-plugin</artifactId>
-                <version>${quarkus.version}</version>
-                <extensions>true</extensions>
-                <executions>
-                    <execution>
-                        <goals>
-                            <goal>build</goal>
-                            <goal>generate-code</goal>
-                            <goal>generate-code-tests</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-compiler-plugin</artifactId>
-                <version>${maven-compiler-plugin.version}</version>
-            </plugin>
-        </plugins>
-    </build>
 
     <profiles>
         <profile>

--- a/profiling/kafka/minio-kafka/pom.xml
+++ b/profiling/kafka/minio-kafka/pom.xml
@@ -34,52 +34,6 @@
     <name>Camel Performance :: Profiling :: Minio Kafka</name>
     <description>A Minio to Kafka containeraized application to show profiling practices</description>
 
-    <properties>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-
-        <exec-maven-plugin.version>3.0.0</exec-maven-plugin.version>
-        <maven-compiler-plugin.version>3.8.1</maven-compiler-plugin.version>
-        <maven.compiler.parameters>true</maven.compiler.parameters>
-        <maven.compiler.source>11</maven.compiler.source>
-        <maven.compiler.target>11</maven.compiler.target>
-
-        <quarkus.version>2.2.0.Final</quarkus.version>
-        <quarkus.container-image.build>true</quarkus.container-image.build>
-        <quarkus.container-image.group>quay.io/oscerd</quarkus.container-image.group>
-        <quarkus.container-image.name>${project.artifactId}</quarkus.container-image.name>
-
-        <camel-k-runtime.version>1.9.0</camel-k-runtime.version>
-        <camel-quarkus.version>2.2.0</camel-quarkus.version>
-        <camel-kamelets-catalog.version>0.4.0</camel-kamelets-catalog.version>
-    </properties>
-
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>io.quarkus</groupId>
-                <artifactId>quarkus-bom</artifactId>
-                <version>${quarkus.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.camel.k</groupId>
-                <artifactId>camel-k-runtime-bom</artifactId>
-                <version>${camel-k-runtime.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.camel.quarkus</groupId>
-                <artifactId>camel-quarkus-bom</artifactId>
-                <version>${camel-quarkus.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
-
     <dependencies>
         <dependency>
             <groupId>io.quarkus</groupId>
@@ -115,31 +69,6 @@
             <version>${camel-kamelets-catalog.version}</version>
         </dependency>
     </dependencies>
-
-    <build>
-        <plugins>
-            <plugin>
-                <groupId>io.quarkus</groupId>
-                <artifactId>quarkus-maven-plugin</artifactId>
-                <version>${quarkus.version}</version>
-                <extensions>true</extensions>
-                <executions>
-                    <execution>
-                        <goals>
-                            <goal>build</goal>
-                            <goal>generate-code</goal>
-                            <goal>generate-code-tests</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-compiler-plugin</artifactId>
-                <version>${maven-compiler-plugin.version}</version>
-            </plugin>
-        </plugins>
-    </build>
 
     <profiles>
         <profile>

--- a/profiling/kafka/mongo-kafka-exchange-pooling/pom.xml
+++ b/profiling/kafka/mongo-kafka-exchange-pooling/pom.xml
@@ -34,52 +34,6 @@
     <name>Camel Performance :: Profiling :: MongoDB Kafka Exchange Pooling</name>
     <description>A MongoDB to Kafka with Exchange Pooling containeraized application to show profiling practices</description>
 
-    <properties>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-
-        <exec-maven-plugin.version>3.0.0</exec-maven-plugin.version>
-        <maven-compiler-plugin.version>3.8.1</maven-compiler-plugin.version>
-        <maven.compiler.parameters>true</maven.compiler.parameters>
-        <maven.compiler.source>11</maven.compiler.source>
-        <maven.compiler.target>11</maven.compiler.target>
-
-        <quarkus.version>2.2.0.Final</quarkus.version>
-        <quarkus.container-image.build>true</quarkus.container-image.build>
-        <quarkus.container-image.group>quay.io/oscerd</quarkus.container-image.group>
-        <quarkus.container-image.name>${project.artifactId}</quarkus.container-image.name>
-
-        <camel-k-runtime.version>1.9.0</camel-k-runtime.version>
-        <camel-quarkus.version>2.2.0</camel-quarkus.version>
-        <camel-kamelets-catalog.version>0.4.0</camel-kamelets-catalog.version>
-    </properties>
-
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>io.quarkus</groupId>
-                <artifactId>quarkus-bom</artifactId>
-                <version>${quarkus.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.camel.k</groupId>
-                <artifactId>camel-k-runtime-bom</artifactId>
-                <version>${camel-k-runtime.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.camel.quarkus</groupId>
-                <artifactId>camel-quarkus-bom</artifactId>
-                <version>${camel-quarkus.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
-
     <dependencies>
         <dependency>
             <groupId>io.quarkus</groupId>
@@ -111,31 +65,6 @@
             <version>${camel-kamelets-catalog.version}</version>
         </dependency>
     </dependencies>
-
-    <build>
-        <plugins>
-            <plugin>
-                <groupId>io.quarkus</groupId>
-                <artifactId>quarkus-maven-plugin</artifactId>
-                <version>${quarkus.version}</version>
-                <extensions>true</extensions>
-                <executions>
-                    <execution>
-                        <goals>
-                            <goal>build</goal>
-                            <goal>generate-code</goal>
-                            <goal>generate-code-tests</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-compiler-plugin</artifactId>
-                <version>${maven-compiler-plugin.version}</version>
-            </plugin>
-        </plugins>
-    </build>
 
     <profiles>
         <profile>

--- a/profiling/kafka/mongo-kafka/pom.xml
+++ b/profiling/kafka/mongo-kafka/pom.xml
@@ -34,52 +34,6 @@
     <name>Camel Performance :: Profiling :: MongoDB Kafka</name>
     <description>A MongoDB to Kafka containeraized application to show profiling practices</description>
 
-    <properties>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-
-        <exec-maven-plugin.version>3.0.0</exec-maven-plugin.version>
-        <maven-compiler-plugin.version>3.8.1</maven-compiler-plugin.version>
-        <maven.compiler.parameters>true</maven.compiler.parameters>
-        <maven.compiler.source>11</maven.compiler.source>
-        <maven.compiler.target>11</maven.compiler.target>
-
-        <quarkus.version>2.2.0.Final</quarkus.version>
-        <quarkus.container-image.build>true</quarkus.container-image.build>
-        <quarkus.container-image.group>quay.io/oscerd</quarkus.container-image.group>
-        <quarkus.container-image.name>${project.artifactId}</quarkus.container-image.name>
-
-        <camel-k-runtime.version>1.9.0</camel-k-runtime.version>
-        <camel-quarkus.version>2.2.0</camel-quarkus.version>
-        <camel-kamelets-catalog.version>0.4.0</camel-kamelets-catalog.version>
-    </properties>
-
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>io.quarkus</groupId>
-                <artifactId>quarkus-bom</artifactId>
-                <version>${quarkus.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.camel.k</groupId>
-                <artifactId>camel-k-runtime-bom</artifactId>
-                <version>${camel-k-runtime.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.camel.quarkus</groupId>
-                <artifactId>camel-quarkus-bom</artifactId>
-                <version>${camel-quarkus.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
-
     <dependencies>
         <dependency>
             <groupId>io.quarkus</groupId>
@@ -111,31 +65,6 @@
             <version>${camel-kamelets-catalog.version}</version>
         </dependency>
     </dependencies>
-
-    <build>
-        <plugins>
-            <plugin>
-                <groupId>io.quarkus</groupId>
-                <artifactId>quarkus-maven-plugin</artifactId>
-                <version>${quarkus.version}</version>
-                <extensions>true</extensions>
-                <executions>
-                    <execution>
-                        <goals>
-                            <goal>build</goal>
-                            <goal>generate-code</goal>
-                            <goal>generate-code-tests</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-compiler-plugin</artifactId>
-                <version>${maven-compiler-plugin.version}</version>
-            </plugin>
-        </plugins>
-    </build>
 
     <profiles>
         <profile>

--- a/profiling/kafka/nats-kafka-exchange-pooling/pom.xml
+++ b/profiling/kafka/nats-kafka-exchange-pooling/pom.xml
@@ -34,52 +34,6 @@
     <name>Camel Performance :: Profiling :: Nats Kafka Exchange Pooling</name>
     <description>A Nats to Kafka with Exchange Pooling containeraized application to show profiling practices</description>
 
-    <properties>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-
-        <exec-maven-plugin.version>3.0.0</exec-maven-plugin.version>
-        <maven-compiler-plugin.version>3.8.1</maven-compiler-plugin.version>
-        <maven.compiler.parameters>true</maven.compiler.parameters>
-        <maven.compiler.source>11</maven.compiler.source>
-        <maven.compiler.target>11</maven.compiler.target>
-
-        <quarkus.version>2.2.0.Final</quarkus.version>
-        <quarkus.container-image.build>true</quarkus.container-image.build>
-        <quarkus.container-image.group>quay.io/oscerd</quarkus.container-image.group>
-        <quarkus.container-image.name>${project.artifactId}</quarkus.container-image.name>
-
-        <camel-k-runtime.version>1.9.0</camel-k-runtime.version>
-        <camel-quarkus.version>2.2.0</camel-quarkus.version>
-        <camel-kamelets-catalog.version>0.4.0</camel-kamelets-catalog.version>
-    </properties>
-
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>io.quarkus</groupId>
-                <artifactId>quarkus-bom</artifactId>
-                <version>${quarkus.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.camel.k</groupId>
-                <artifactId>camel-k-runtime-bom</artifactId>
-                <version>${camel-k-runtime.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.camel.quarkus</groupId>
-                <artifactId>camel-quarkus-bom</artifactId>
-                <version>${camel-quarkus.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
-
     <dependencies>
         <dependency>
             <groupId>io.quarkus</groupId>
@@ -115,31 +69,6 @@
             <version>${camel-kamelets-catalog.version}</version>
         </dependency>
     </dependencies>
-
-    <build>
-        <plugins>
-            <plugin>
-                <groupId>io.quarkus</groupId>
-                <artifactId>quarkus-maven-plugin</artifactId>
-                <version>${quarkus.version}</version>
-                <extensions>true</extensions>
-                <executions>
-                    <execution>
-                        <goals>
-                            <goal>build</goal>
-                            <goal>generate-code</goal>
-                            <goal>generate-code-tests</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-compiler-plugin</artifactId>
-                <version>${maven-compiler-plugin.version}</version>
-            </plugin>
-        </plugins>
-    </build>
 
     <profiles>
         <profile>

--- a/profiling/kafka/nats-kafka/pom.xml
+++ b/profiling/kafka/nats-kafka/pom.xml
@@ -34,52 +34,6 @@
     <name>Camel Performance :: Profiling :: Nats Kafka</name>
     <description>A Nats to Kafka containeraized application to show profiling practices</description>
 
-    <properties>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-
-        <exec-maven-plugin.version>3.0.0</exec-maven-plugin.version>
-        <maven-compiler-plugin.version>3.8.1</maven-compiler-plugin.version>
-        <maven.compiler.parameters>true</maven.compiler.parameters>
-        <maven.compiler.source>11</maven.compiler.source>
-        <maven.compiler.target>11</maven.compiler.target>
-
-        <quarkus.version>2.2.0.Final</quarkus.version>
-        <quarkus.container-image.build>true</quarkus.container-image.build>
-        <quarkus.container-image.group>quay.io/oscerd</quarkus.container-image.group>
-        <quarkus.container-image.name>${project.artifactId}</quarkus.container-image.name>
-
-        <camel-k-runtime.version>1.9.0</camel-k-runtime.version>
-        <camel-quarkus.version>2.2.0</camel-quarkus.version>
-        <camel-kamelets-catalog.version>0.4.0</camel-kamelets-catalog.version>
-    </properties>
-
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>io.quarkus</groupId>
-                <artifactId>quarkus-bom</artifactId>
-                <version>${quarkus.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.camel.k</groupId>
-                <artifactId>camel-k-runtime-bom</artifactId>
-                <version>${camel-k-runtime.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.camel.quarkus</groupId>
-                <artifactId>camel-quarkus-bom</artifactId>
-                <version>${camel-quarkus.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
-
     <dependencies>
         <dependency>
             <groupId>io.quarkus</groupId>
@@ -115,31 +69,6 @@
             <version>${camel-kamelets-catalog.version}</version>
         </dependency>
     </dependencies>
-
-    <build>
-        <plugins>
-            <plugin>
-                <groupId>io.quarkus</groupId>
-                <artifactId>quarkus-maven-plugin</artifactId>
-                <version>${quarkus.version}</version>
-                <extensions>true</extensions>
-                <executions>
-                    <execution>
-                        <goals>
-                            <goal>build</goal>
-                            <goal>generate-code</goal>
-                            <goal>generate-code-tests</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-compiler-plugin</artifactId>
-                <version>${maven-compiler-plugin.version}</version>
-            </plugin>
-        </plugins>
-    </build>
 
     <profiles>
         <profile>

--- a/profiling/kafka/pom.xml
+++ b/profiling/kafka/pom.xml
@@ -34,6 +34,77 @@
     <packaging>pom</packaging>
     <name>Camel Performance :: Profiling :: Kafka Parent</name>
 
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+
+        <exec-maven-plugin.version>3.0.0</exec-maven-plugin.version>
+        <maven-compiler-plugin.version>3.8.1</maven-compiler-plugin.version>
+        <maven.compiler.parameters>true</maven.compiler.parameters>
+        <maven.compiler.source>11</maven.compiler.source>
+        <maven.compiler.target>11</maven.compiler.target>
+
+        <quarkus.version>2.4.0.Final</quarkus.version>
+        <quarkus.container-image.build>true</quarkus.container-image.build>
+        <quarkus.container-image.group>quay.io/oscerd</quarkus.container-image.group>
+        <quarkus.container-image.name>${project.artifactId}</quarkus.container-image.name>
+
+        <camel-k-runtime.version>1.10.0</camel-k-runtime.version>
+        <camel-quarkus.version>2.4.0</camel-quarkus.version>
+        <camel-kamelets-catalog.version>0.5.0</camel-kamelets-catalog.version>
+    </properties>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>io.quarkus</groupId>
+                <artifactId>quarkus-bom</artifactId>
+                <version>${quarkus.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.camel.k</groupId>
+                <artifactId>camel-k-runtime-bom</artifactId>
+                <version>${camel-k-runtime.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.camel.quarkus</groupId>
+                <artifactId>camel-quarkus-bom</artifactId>
+                <version>${camel-quarkus.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>io.quarkus</groupId>
+                <artifactId>quarkus-maven-plugin</artifactId>
+                <version>${quarkus.version}</version>
+                <extensions>true</extensions>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>build</goal>
+                            <goal>generate-code</goal>
+                            <goal>generate-code-tests</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>${maven-compiler-plugin.version}</version>
+            </plugin>
+        </plugins>
+    </build>
+
     <modules>
         <module>kafka-s3</module>
         <module>kafka-s3-exchange-pooling</module>

--- a/profiling/kafka/postgresql-kafka-exchange-pooling/pom.xml
+++ b/profiling/kafka/postgresql-kafka-exchange-pooling/pom.xml
@@ -34,6 +34,37 @@
     <name>Camel Performance :: Profiling :: PostgreSQL Kafka Exchange Pooling</name>
     <description>A PostgreSQL to Kafka with Exchange Pooling containeraized application to show profiling practices</description>
 
+    <properties>
+        <postgresql-driver-version>42.2.14</postgresql-driver-version>
+        <commons-dbcp2-version>2.8.0</commons-dbcp2-version>
+    </properties>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>io.quarkus</groupId>
+                <artifactId>quarkus-bom</artifactId>
+                <version>${quarkus.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.camel.k</groupId>
+                <artifactId>camel-k-runtime-bom</artifactId>
+                <version>${camel-k-runtime.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.camel.quarkus</groupId>
+                <artifactId>camel-quarkus-bom</artifactId>
+                <version>${camel-quarkus.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
     <dependencies>
         <dependency>
             <groupId>io.quarkus</groupId>
@@ -79,6 +110,31 @@
             <version>${postgresql-driver-version}</version>
         </dependency>
     </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>io.quarkus</groupId>
+                <artifactId>quarkus-maven-plugin</artifactId>
+                <version>${quarkus.version}</version>
+                <extensions>true</extensions>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>build</goal>
+                            <goal>generate-code</goal>
+                            <goal>generate-code-tests</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>${maven-compiler-plugin.version}</version>
+            </plugin>
+        </plugins>
+    </build>
 
     <profiles>
         <profile>

--- a/profiling/kafka/postgresql-kafka-exchange-pooling/pom.xml
+++ b/profiling/kafka/postgresql-kafka-exchange-pooling/pom.xml
@@ -111,31 +111,6 @@
         </dependency>
     </dependencies>
 
-    <build>
-        <plugins>
-            <plugin>
-                <groupId>io.quarkus</groupId>
-                <artifactId>quarkus-maven-plugin</artifactId>
-                <version>${quarkus.version}</version>
-                <extensions>true</extensions>
-                <executions>
-                    <execution>
-                        <goals>
-                            <goal>build</goal>
-                            <goal>generate-code</goal>
-                            <goal>generate-code-tests</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-compiler-plugin</artifactId>
-                <version>${maven-compiler-plugin.version}</version>
-            </plugin>
-        </plugins>
-    </build>
-
     <profiles>
         <profile>
             <id>jvm</id>

--- a/profiling/kafka/postgresql-kafka-exchange-pooling/pom.xml
+++ b/profiling/kafka/postgresql-kafka-exchange-pooling/pom.xml
@@ -34,54 +34,6 @@
     <name>Camel Performance :: Profiling :: PostgreSQL Kafka Exchange Pooling</name>
     <description>A PostgreSQL to Kafka with Exchange Pooling containeraized application to show profiling practices</description>
 
-    <properties>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-
-        <exec-maven-plugin.version>3.0.0</exec-maven-plugin.version>
-        <maven-compiler-plugin.version>3.8.1</maven-compiler-plugin.version>
-        <maven.compiler.parameters>true</maven.compiler.parameters>
-        <maven.compiler.source>11</maven.compiler.source>
-        <maven.compiler.target>11</maven.compiler.target>
-
-        <quarkus.version>2.2.0.Final</quarkus.version>
-        <quarkus.container-image.build>true</quarkus.container-image.build>
-        <quarkus.container-image.group>quay.io/oscerd</quarkus.container-image.group>
-        <quarkus.container-image.name>${project.artifactId}</quarkus.container-image.name>
-
-        <camel-k-runtime.version>1.9.0</camel-k-runtime.version>
-        <camel-quarkus.version>2.2.0</camel-quarkus.version>
-        <camel-kamelets-catalog.version>0.4.0</camel-kamelets-catalog.version>
-        <postgresql-driver-version>42.2.14</postgresql-driver-version>
-        <commons-dbcp2-version>2.8.0</commons-dbcp2-version>
-    </properties>
-
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>io.quarkus</groupId>
-                <artifactId>quarkus-bom</artifactId>
-                <version>${quarkus.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.camel.k</groupId>
-                <artifactId>camel-k-runtime-bom</artifactId>
-                <version>${camel-k-runtime.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.camel.quarkus</groupId>
-                <artifactId>camel-quarkus-bom</artifactId>
-                <version>${camel-quarkus.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
-
     <dependencies>
         <dependency>
             <groupId>io.quarkus</groupId>
@@ -127,31 +79,6 @@
             <version>${postgresql-driver-version}</version>
         </dependency>
     </dependencies>
-
-    <build>
-        <plugins>
-            <plugin>
-                <groupId>io.quarkus</groupId>
-                <artifactId>quarkus-maven-plugin</artifactId>
-                <version>${quarkus.version}</version>
-                <extensions>true</extensions>
-                <executions>
-                    <execution>
-                        <goals>
-                            <goal>build</goal>
-                            <goal>generate-code</goal>
-                            <goal>generate-code-tests</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-compiler-plugin</artifactId>
-                <version>${maven-compiler-plugin.version}</version>
-            </plugin>
-        </plugins>
-    </build>
 
     <profiles>
         <profile>

--- a/profiling/kafka/postgresql-kafka/pom.xml
+++ b/profiling/kafka/postgresql-kafka/pom.xml
@@ -34,54 +34,6 @@
     <name>Camel Performance :: Profiling :: PostgreSQL Kafka</name>
     <description>A PostgreSQL to Kafka containeraized application to show profiling practices</description>
 
-    <properties>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-
-        <exec-maven-plugin.version>3.0.0</exec-maven-plugin.version>
-        <maven-compiler-plugin.version>3.8.1</maven-compiler-plugin.version>
-        <maven.compiler.parameters>true</maven.compiler.parameters>
-        <maven.compiler.source>11</maven.compiler.source>
-        <maven.compiler.target>11</maven.compiler.target>
-
-        <quarkus.version>2.2.0.Final</quarkus.version>
-        <quarkus.container-image.build>true</quarkus.container-image.build>
-        <quarkus.container-image.group>quay.io/oscerd</quarkus.container-image.group>
-        <quarkus.container-image.name>${project.artifactId}</quarkus.container-image.name>
-
-        <camel-k-runtime.version>1.9.0</camel-k-runtime.version>
-        <camel-quarkus.version>2.2.0</camel-quarkus.version>
-        <camel-kamelets-catalog.version>0.4.0</camel-kamelets-catalog.version>
-        <postgresql-driver-version>42.2.14</postgresql-driver-version>
-        <commons-dbcp2-version>2.8.0</commons-dbcp2-version>
-    </properties>
-
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>io.quarkus</groupId>
-                <artifactId>quarkus-bom</artifactId>
-                <version>${quarkus.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.camel.k</groupId>
-                <artifactId>camel-k-runtime-bom</artifactId>
-                <version>${camel-k-runtime.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.camel.quarkus</groupId>
-                <artifactId>camel-quarkus-bom</artifactId>
-                <version>${camel-quarkus.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
-
     <dependencies>
         <dependency>
             <groupId>io.quarkus</groupId>
@@ -127,31 +79,6 @@
             <version>${postgresql-driver-version}</version>
         </dependency>
     </dependencies>
-
-    <build>
-        <plugins>
-            <plugin>
-                <groupId>io.quarkus</groupId>
-                <artifactId>quarkus-maven-plugin</artifactId>
-                <version>${quarkus.version}</version>
-                <extensions>true</extensions>
-                <executions>
-                    <execution>
-                        <goals>
-                            <goal>build</goal>
-                            <goal>generate-code</goal>
-                            <goal>generate-code-tests</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-compiler-plugin</artifactId>
-                <version>${maven-compiler-plugin.version}</version>
-            </plugin>
-        </plugins>
-    </build>
 
     <profiles>
         <profile>

--- a/profiling/kafka/postgresql-kafka/pom.xml
+++ b/profiling/kafka/postgresql-kafka/pom.xml
@@ -34,6 +34,11 @@
     <name>Camel Performance :: Profiling :: PostgreSQL Kafka</name>
     <description>A PostgreSQL to Kafka containeraized application to show profiling practices</description>
 
+    <properties>
+        <postgresql-driver-version>42.2.14</postgresql-driver-version>
+        <commons-dbcp2-version>2.8.0</commons-dbcp2-version>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>io.quarkus</groupId>
@@ -79,6 +84,31 @@
             <version>${postgresql-driver-version}</version>
         </dependency>
     </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>io.quarkus</groupId>
+                <artifactId>quarkus-maven-plugin</artifactId>
+                <version>${quarkus.version}</version>
+                <extensions>true</extensions>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>build</goal>
+                            <goal>generate-code</goal>
+                            <goal>generate-code-tests</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>${maven-compiler-plugin.version}</version>
+            </plugin>
+        </plugins>
+    </build>
 
     <profiles>
         <profile>

--- a/profiling/kafka/s3-kafka-exchange-pooling/pom.xml
+++ b/profiling/kafka/s3-kafka-exchange-pooling/pom.xml
@@ -34,52 +34,6 @@
     <name>Camel Performance :: Profiling :: S3 Kafka Exchange Pooling</name>
     <description>An S3 to Kafka with Exchange pooling containeraized application to show profiling practices</description>
 
-    <properties>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-
-        <exec-maven-plugin.version>3.0.0</exec-maven-plugin.version>
-        <maven-compiler-plugin.version>3.8.1</maven-compiler-plugin.version>
-        <maven.compiler.parameters>true</maven.compiler.parameters>
-        <maven.compiler.source>11</maven.compiler.source>
-        <maven.compiler.target>11</maven.compiler.target>
-
-        <quarkus.version>2.2.0.Final</quarkus.version>
-        <quarkus.container-image.build>true</quarkus.container-image.build>
-        <quarkus.container-image.group>quay.io/oscerd</quarkus.container-image.group>
-        <quarkus.container-image.name>${project.artifactId}</quarkus.container-image.name>
-
-        <camel-k-runtime.version>1.9.0</camel-k-runtime.version>
-        <camel-quarkus.version>2.2.0</camel-quarkus.version>
-        <camel-kamelets-catalog.version>0.4.0</camel-kamelets-catalog.version>
-    </properties>
-
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>io.quarkus</groupId>
-                <artifactId>quarkus-bom</artifactId>
-                <version>${quarkus.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.camel.k</groupId>
-                <artifactId>camel-k-runtime-bom</artifactId>
-                <version>${camel-k-runtime.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.camel.quarkus</groupId>
-                <artifactId>camel-quarkus-bom</artifactId>
-                <version>${camel-quarkus.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
-
     <dependencies>
         <dependency>
             <groupId>io.quarkus</groupId>
@@ -111,31 +65,6 @@
             <version>${camel-kamelets-catalog.version}</version>
         </dependency>
     </dependencies>
-
-    <build>
-        <plugins>
-            <plugin>
-                <groupId>io.quarkus</groupId>
-                <artifactId>quarkus-maven-plugin</artifactId>
-                <version>${quarkus.version}</version>
-                <extensions>true</extensions>
-                <executions>
-                    <execution>
-                        <goals>
-                            <goal>build</goal>
-                            <goal>generate-code</goal>
-                            <goal>generate-code-tests</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-compiler-plugin</artifactId>
-                <version>${maven-compiler-plugin.version}</version>
-            </plugin>
-        </plugins>
-    </build>
 
     <profiles>
         <profile>

--- a/profiling/kafka/s3-kafka/pom.xml
+++ b/profiling/kafka/s3-kafka/pom.xml
@@ -34,52 +34,6 @@
     <name>Camel Performance :: Profiling :: S3 Kafka</name>
     <description>An S3 to Kafka containeraized application to show profiling practices</description>
 
-    <properties>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-
-        <exec-maven-plugin.version>3.0.0</exec-maven-plugin.version>
-        <maven-compiler-plugin.version>3.8.1</maven-compiler-plugin.version>
-        <maven.compiler.parameters>true</maven.compiler.parameters>
-        <maven.compiler.source>11</maven.compiler.source>
-        <maven.compiler.target>11</maven.compiler.target>
-
-        <quarkus.version>2.2.0.Final</quarkus.version>
-        <quarkus.container-image.build>true</quarkus.container-image.build>
-        <quarkus.container-image.group>quay.io/oscerd</quarkus.container-image.group>
-        <quarkus.container-image.name>${project.artifactId}</quarkus.container-image.name>
-
-        <camel-k-runtime.version>1.9.0</camel-k-runtime.version>
-        <camel-quarkus.version>2.2.0</camel-quarkus.version>
-        <camel-kamelets-catalog.version>0.4.0</camel-kamelets-catalog.version>
-    </properties>
-
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>io.quarkus</groupId>
-                <artifactId>quarkus-bom</artifactId>
-                <version>${quarkus.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.camel.k</groupId>
-                <artifactId>camel-k-runtime-bom</artifactId>
-                <version>${camel-k-runtime.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.camel.quarkus</groupId>
-                <artifactId>camel-quarkus-bom</artifactId>
-                <version>${camel-quarkus.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
-
     <dependencies>
         <dependency>
             <groupId>io.quarkus</groupId>
@@ -111,31 +65,6 @@
             <version>${camel-kamelets-catalog.version}</version>
         </dependency>
     </dependencies>
-
-    <build>
-        <plugins>
-            <plugin>
-                <groupId>io.quarkus</groupId>
-                <artifactId>quarkus-maven-plugin</artifactId>
-                <version>${quarkus.version}</version>
-                <extensions>true</extensions>
-                <executions>
-                    <execution>
-                        <goals>
-                            <goal>build</goal>
-                            <goal>generate-code</goal>
-                            <goal>generate-code-tests</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-compiler-plugin</artifactId>
-                <version>${maven-compiler-plugin.version}</version>
-            </plugin>
-        </plugins>
-    </build>
 
     <profiles>
         <profile>


### PR DESCRIPTION
And move to Quarkus 2.4.0.Final, camel-quarkus 2.4.0 and camel-k-runtime 1.10.0