### PR TITLE
Configure GitHub workflow to cancel previous PR check in case of new

### DIFF
--- a/.github/workflows/pr-build-main.yml
+++ b/.github/workflows/pr-build-main.yml
@@ -27,6 +27,10 @@ on:
       - NOTICE.txt
       - LICENSE.txt
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
 jobs:
   compile:
     if: github.repository == 'apache/camel-performance-tests'


### PR DESCRIPTION
commits on same PR

It will save some resources in case of new commit on a branch PR and PR checks were not finished
Apache committers can see recommendations here
https://cwiki.apache.org/confluence/pages/viewpage.action?spaceKey=INFRA&title=GitHub+Actions+Recommended+Practices