### PR TITLE
Play tests on GitHub Actions CI

### DIFF
--- a/.github/workflows/pr-build-main.yml
+++ b/.github/workflows/pr-build-main.yml
@@ -46,4 +46,4 @@ jobs:
         java-version: 17
         cache: 'maven'
     - name: Maven build
-      run: mvn -V -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.httpconnectionManager.ttlSeconds=120 --no-transfer-progress clean compile
+      run: mvn -V -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.httpconnectionManager.ttlSeconds=120 --no-transfer-progress clean verify

--- a/profiling/kafka/kafka-solr-exchange-pooling/pom.xml
+++ b/profiling/kafka/kafka-solr-exchange-pooling/pom.xml
@@ -49,7 +49,7 @@
         <quarkus.container-image.group>quay.io/oscerd</quarkus.container-image.group>
         <quarkus.container-image.name>${project.artifactId}</quarkus.container-image.name>
 
-        <camel-k-runtime.version>3.15.3</camel-k-runtime.version>
+        <camel-k-runtime.version>1.9.0</camel-k-runtime.version>
         <camel-quarkus.version>2.2.0</camel-quarkus.version>
         <camel-kamelets-catalog.version>main-SNAPSHOT</camel-kamelets-catalog.version>
     </properties>

--- a/profiling/kafka/kafka-solr/pom.xml
+++ b/profiling/kafka/kafka-solr/pom.xml
@@ -49,7 +49,7 @@
         <quarkus.container-image.group>quay.io/oscerd</quarkus.container-image.group>
         <quarkus.container-image.name>${project.artifactId}</quarkus.container-image.name>
 
-        <camel-k-runtime.version>3.15.3</camel-k-runtime.version>
+        <camel-k-runtime.version>1.9.0</camel-k-runtime.version>
         <camel-quarkus.version>2.2.0</camel-quarkus.version>
         <camel-kamelets-catalog.version>main-SNAPSHOT</camel-kamelets-catalog.version>
     </properties>

--- a/profiling/kafka/pom.xml
+++ b/profiling/kafka/pom.xml
@@ -49,7 +49,7 @@
         <quarkus.container-image.group>quay.io/oscerd</quarkus.container-image.group>
         <quarkus.container-image.name>${project.artifactId}</quarkus.container-image.name>
 
-        <camel-k-runtime.version>3.15.3</camel-k-runtime.version>
+        <camel-k-runtime.version>1.14.0</camel-k-runtime.version>
         <camel-quarkus.version>2.11.0</camel-quarkus.version>
         <camel-kamelets-catalog.version>0.9.0</camel-kamelets-catalog.version>
     </properties>

--- a/tests/camel-jmh/src/test/java/org/apache/camel/itest/jmh/FileComponentPollingDirectoryTest.java
+++ b/tests/camel-jmh/src/test/java/org/apache/camel/itest/jmh/FileComponentPollingDirectoryTest.java
@@ -26,6 +26,7 @@ import java.util.List;
 import java.util.concurrent.TimeUnit;
 
 import org.apache.camel.CamelContext;
+import org.apache.camel.Exchange;
 import org.apache.camel.Processor;
 import org.apache.camel.component.file.FileConsumer;
 import org.apache.camel.component.file.FileEndpoint;
@@ -67,8 +68,8 @@ public class FileComponentPollingDirectoryTest {
         }
 
         @Override
-        public boolean pollDirectory(String fileName, List<GenericFile<File>> fileList, int depth) {
-            return super.pollDirectory(fileName, fileList, depth);
+        public boolean pollDirectory(Exchange dynamic, String fileName, List<GenericFile<File>> fileList, int depth) {
+            return super.pollDirectory(dynamic, fileName, fileList, depth);
         }
     }
 
@@ -113,7 +114,7 @@ public class FileComponentPollingDirectoryTest {
     @Benchmark
     public void testFilePolling() {
         System.out.println("Polling from " + inputDir);
-        consumer.pollDirectory(inputDir, fileList, 0);
+        consumer.pollDirectory(endpoint.createExchange() , inputDir, fileList, 0);
         System.out.println("Polled files: " + fileList.size());
     }
 


### PR DESCRIPTION
it also enables the compilation of tests

had to revert the camel k runtime upgrade and fix a compilation issue due to upgrade from Camel 4.7 to 4.20; Both of these were down recently triggered by dependabot and were not caught due to tests not even compiled on CI